### PR TITLE
Fix Critical Vulnerability Dependencies & Add `npm run dev` 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fiscalapi",
-  "version": "4.0.141",
+  "version": "4.0.270",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fiscalapi",
-      "version": "4.0.141",
+      "version": "4.0.270",
       "license": "MPL-2.0",
       "dependencies": {
         "axios": "^1.8.4",
@@ -192,9 +192,9 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -380,13 +380,14 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test": "jest",
     "lint": "eslint 'src/**/*.ts'",
     "prepare": "npm run build",
-    "main": "ts-node examples/main.ts"
+    "main": "ts-node examples/main.ts",
+    "dev": "ts-node examples/all-samples.ts"
   },
   "keywords": [
     "fiscalapi",


### PR DESCRIPTION
This pull request introduces 2 new changes:

- A new npm script to make development easier. A `dev` script has been added to run `ts-node examples/all-samples.ts`, allowing you to quickly execute all sample code during development.
- Ran `npm audit fix` to patch high and critical vulnerabilities


<img width="891" height="275" alt="Screenshot 2025-08-31 at 3 41 34 PM" src="https://github.com/user-attachments/assets/3cea04a1-2a44-4f5d-8b18-f3c62b3849e6" />
